### PR TITLE
len() check for empty series

### DIFF
--- a/prepare_data.py
+++ b/prepare_data.py
@@ -78,10 +78,11 @@ def make_windows(datafile, winsec=10, sample_rate=SAMPLE_RATE, dropna=True):
         xyz = w[['x', 'y', 'z']].to_numpy()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="Unable to sort modes")
-            if len(w['annotation'].mode(dropna=False)) == 0:
-                anno = pd.NA
+            anno = w['annotation'].mode(dropna=False)
+            if len(anno) > 0:
+                anno = anno.iloc[0]
             else:
-                anno = w['annotation'].mode(dropna=False).iloc[0]
+                anno = pd.NA
 
         if dropna and pd.isna(anno):  # skip if annotation is NA
             continue

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -78,7 +78,10 @@ def make_windows(datafile, winsec=10, sample_rate=SAMPLE_RATE, dropna=True):
         xyz = w[['x', 'y', 'z']].to_numpy()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="Unable to sort modes")
-            anno = w['annotation'].mode(dropna=False).iloc[0]
+            if len(w['annotation'].mode(dropna=False)) == 0:
+                anno = pd.NA
+            else:
+                anno = w['annotation'].mode(dropna=False).iloc[0]
 
         if dropna and pd.isna(anno):  # skip if annotation is NA
             continue


### PR DESCRIPTION
For P008.csv, the annotation cell is sometimes empty. So, it throws an error when it comes to the following line:
anno = w['annotation'].mode(dropna=False).iloc[0]

I have resolved this issue by putting a check first to see whether the series is empty or not (so it's okay to use  iloc[0]).
